### PR TITLE
Fix v-structure learning in MARVEL

### DIFF
--- a/rcd/marvel/marvel.py
+++ b/rcd/marvel/marvel.py
@@ -359,7 +359,7 @@ class Marvel:
                 sep_set = y_sep_set_dict[var_y]
                 if var_z not in sep_set and is_y_z_neighbor(var_y, var_z):
                     x_v_structure_dict = self.v_structure_dict.get(var_idx, dict())
-                    z_set = x_v_structure_dict.get(var_z, set())
+                    z_set = x_v_structure_dict.get(var_y, set())
                     z_set.add(var_z)
                     x_v_structure_dict[var_y] = z_set
                     self.v_structure_dict[var_idx] = x_v_structure_dict


### PR DESCRIPTION
In `Marvel`, the attribute `v_structure_dict` is a "dictionary that maps x to a dictionary that maps y to a set of variables v, such that x->v<-y is a v-structure". This dictionary gets populated in the function `learn_v_structure`, where [line #362](https://github.com/ban-epfl/rcd/blob/main/rcd/marvel/marvel.py#L362) should obtain the already discovered set of "v" variables `z_set` between `var_idx` and the current `var_y`. Currently, this line contains an error because it instead obtains the set of colliders between `var_idx` and `var_z`, which is the variable to be added to the set. This PR fixes this error.

The error can be reproduced with the following code, where MARVEL, using oracle CI tests, learns a wrong skeleton with a superfluous edge between node 1 and 2 (indexed from 0).

```python3
import numpy as np
import networkx as nx
import pandas as pd
import matplotlib.pyplot as plt

from rcd.marvel.marvel import Marvel

# Example DAG
amat = np.array([
    [0, 0, 1, 1, 1],
    [0, 0, 0, 1, 1],
    [0, 0, 0, 0, 1],
    [0, 0, 1, 0, 1],
    [0, 0, 0, 0, 0]
])
true_dag = nx.DiGraph(amat)
true_skeleton = nx.Graph(amat)

# Oracle CI test
ci_test = lambda x, y, z, data : nx.d_separated(true_dag, {x}, {y}, set(z))
dummy_data = pd.DataFrame(np.zeros((1,5)))

marvel = Marvel(ci_test)
learned_skeleton = marvel.learn_and_get_skeleton(dummy_data)

assert np.all(nx.to_numpy_array(true_skeleton) == nx.to_numpy_array(learned_skeleton))
```